### PR TITLE
[Bug] batt service is down after upgrade.

### DIFF
--- a/mac/justfile
+++ b/mac/justfile
@@ -1,3 +1,4 @@
+BATT_OUTDATED := if `brew outdated -q | grep batt | wc -l` == '0' { "true" } else { "false" }
 
 # List recipe
 help:
@@ -11,8 +12,8 @@ find-n-preview:
 
 # Show outdated packages
 brew-list-outdated: brew-update
-  brew outdated
-  brew outdated --cask --greedy
+  brew outdated -q
+  brew outdated -q --cask --greedy
 
 # Update brew repos
 brew-update:
@@ -20,12 +21,12 @@ brew-update:
 
 # Upgrade brew packages
 brew-upgrade: brew-update
-  # Adding `-` before a command ignores exit code 0.
-  # `grep` returns 0 if `batt` is not found in outdated package list.
-  -just brew-list-outdated | grep batt && sudo brew services stop batt
+  # Adding `-` before a command ignores exit code 1 (false).
+  -{{BATT_OUTDATED}} && sudo brew services stop batt
   brew upgrade
   brew upgrade --cask --greedy
-  -just brew-list-outdated | grep batt && sudo brew services start batt
+  -{{BATT_OUTDATED}} && sudo brew services start batt
+  #sudo batt status
 
 # Fix brew permission issue
 brew-fix-permission:


### PR DESCRIPTION
Problem:
The 2nd call to `just brew-list-outdated | grep batt ` always returns `false`, because it is after `brew upgrade`.  As a result, `batt` never restart.

Fix:
Save the result as a flag and reuse.

```
# Upgrade brew packages
brew-upgrade: brew-update
  # Adding `-` before a command ignores exit code 0.
  # `grep` returns 0 if `batt` is not found in outdated package list.
  -just brew-list-outdated | grep batt && sudo brew services stop batt
  brew upgrade
  brew upgrade --cask --greedy
  -just brew-list-outdated | grep batt && sudo brew services start batt
```